### PR TITLE
Typing fix

### DIFF
--- a/cqmore/_typing.py
+++ b/cqmore/_typing.py
@@ -1,9 +1,9 @@
-from typing import Iterable, Union
+from typing import Iterable, Union, Tuple, List
 
 from cadquery import Vector
 
-Point2D = tuple[float, float]
-Point3D = tuple[float, float, float]
-FaceIndices = tuple[int, ...]
-MeshGrid = Union[list[list[Point2D]], list[list[Point3D]], list[list[Vector]]]
+Point2D = Tuple[float, float]
+Point3D = Tuple[float, float, float]
+FaceIndices = Tuple[int, ...]
+MeshGrid = Union[List[List[Point2D]], List[List[Point3D]], List[List[Vector]]]
 Polygon = Iterable[Point2D]

--- a/cqmore/_util.py
+++ b/cqmore/_util.py
@@ -1,4 +1,4 @@
-from typing import Iterable, cast
+from typing import Iterable, cast, Tuple
 
 from cadquery import Vector
 from cadquery.cq import VectorLike
@@ -7,15 +7,15 @@ from cadquery.cq import VectorLike
 def signum(n):
     return n and (1, -1)[n < 0]
 
-def toVectors(points: Iterable[VectorLike]) -> tuple[Vector]:
+def toVectors(points: Iterable[VectorLike]) -> Tuple[Vector]:
     if isinstance(next(iter(points)), Vector):
         return cast(tuple[Vector], list(points))
     
-    return cast(tuple[Vector], tuple(Vector(*p) for p in points))
+    return cast(Tuple[Vector], tuple(Vector(*p) for p in points))
 
 
-def toTuples(points: Iterable[VectorLike]) -> tuple[tuple]:
-    if isinstance(next(iter(points)), tuple):
+def toTuples(points: Iterable[VectorLike]) -> Tuple[Tuple]:
+    if isinstance(next(iter(points)), Tuple):
         return cast(tuple[tuple], tuple(points))
 
     r = tuple(v.toTuple() for v in cast(tuple[Vector], points))

--- a/cqmore/_util.py
+++ b/cqmore/_util.py
@@ -16,7 +16,7 @@ def toVectors(points: Iterable[VectorLike]) -> Tuple[Vector]:
 
 def toTuples(points: Iterable[VectorLike]) -> Tuple[Tuple]:
     if isinstance(next(iter(points)), Tuple):
-        return cast(tuple[tuple], tuple(points))
+        return cast(Tuple[tuple], tuple(points))
 
-    r = tuple(v.toTuple() for v in cast(tuple[Vector], points))
-    return cast(tuple[tuple], r)
+    r = tuple(v.toTuple() for v in cast(Tuple[Vector], points))
+    return cast(Tuple[tuple], r)

--- a/cqmore/matrix.py
+++ b/cqmore/matrix.py
@@ -23,7 +23,7 @@ multiplications from right to left.
 
 """
 
-from typing import Iterable, Union, cast
+from typing import Iterable, Union, cast, Tuple
 
 from cadquery import Vector
 
@@ -96,7 +96,7 @@ class Matrix3D:
         return cast(Point3D, tuple((self.wrapped @ vt))[:-1])
 
 
-    def transformAll(self, points: Union[Iterable[Point3D], Iterable[Vector]]) -> tuple[Point3D]:
+    def transformAll(self, points: Union[Iterable[Point3D], Iterable[Vector]]) -> Tuple[Point3D]:
         '''
         Use the current matrix to transform a list of points.
 

--- a/cqmore/matrix.py
+++ b/cqmore/matrix.py
@@ -128,7 +128,7 @@ class Matrix3D:
         else:
             r = (tuple((self.wrapped @ (p + (1,))))[:-1] for p in cast(Iterable[Point3D], points))
         
-        return cast(tuple[Point3D], tuple(r))
+        return cast(Tuple[Point3D], tuple(r))
         
 
 _identity = [

--- a/cqmore/polyhedron.py
+++ b/cqmore/polyhedron.py
@@ -14,7 +14,7 @@ to use them.
 
 from math import cos, radians, sin, pi, tau
 
-from typing import Iterable, NamedTuple, Union, cast, List
+from typing import Iterable, NamedTuple, Tuple, Union, cast, List
 
 from cadquery import Vector
 from cadquery.cq import VectorLike
@@ -496,7 +496,7 @@ def gridSurface(points: MeshGrid, thickness: float = 0) -> Polyhedron:
             )
         )
     else:
-        vectors = cast(tuple[tuple[Vector]],
+        vectors = cast(Tuple[Tuple[Vector]],
             tuple(
                 tuple(Vector(*points[ci][ri]) for ci in range(len(points))) for ri in range(len(points[0]))
             )

--- a/cqmore/polyhedron.py
+++ b/cqmore/polyhedron.py
@@ -14,7 +14,7 @@ to use them.
 
 from math import cos, radians, sin, pi, tau
 
-from typing import Iterable, NamedTuple, Union, cast
+from typing import Iterable, NamedTuple, Union, cast, List
 
 from cadquery import Vector
 from cadquery.cq import VectorLike
@@ -835,7 +835,7 @@ def polarZonohedra(n: int, theta: float = 35.5) -> Polyhedron:
     return Polyhedron(points, faces)
     
 
-def sweep(profiles: Union[list[list[Point3D]], list[list[Vector]]], closeIdx: int = -1) -> Polyhedron:
+def sweep(profiles: Union[List[List[Point3D]], List[List[Vector]]], closeIdx: int = -1) -> Polyhedron:
     """
     Create a swept polyhedron.
 

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1,5 +1,5 @@
 import unittest
-from typing import cast
+from typing import cast, List
 from cadquery import Vector, Vertex, Wire
 from cqmore import Workplane
 
@@ -15,13 +15,13 @@ class TestWorkplane2D(unittest.TestCase):
             False
         )
 
-        expected = cast(list[Wire], 
+        expected = cast(List[Wire], 
                         Workplane().rect(5, 5, forConstruction = True)
                                    .vertices()
                                    .eachpoint(lambda loc: wire.moved(loc))
                                    .vals()
                    )
-        actual = cast(list[Wire], 
+        actual = cast(List[Wire], 
                       Workplane().rect(5, 5, forConstruction = True)
                                  .vertices()
                                  .makePolygon(points)
@@ -141,7 +141,7 @@ class TestWorkplane3D(unittest.TestCase):
         vertices = tetrahedron.vertices()
         self.assertEqual(4, vertices.size())
 
-        actual = cast(list[Vertex], vertices.vals())
+        actual = cast(List[Vertex], vertices.vals())
         self.assertListEqual(
             sorted(points), 
             sorted([v.toTuple() for v in actual])


### PR DESCRIPTION
Adjusted the repository to use `List` and `Tuple` from `typing` instead of regular `list` and `tuple` as specified in Issue #2.

I ran the tests and the only issue happens with `python test_matrix.py`. It would appear that there are tuples that differ but the difference seems to be quite insignificant (several hundreds of digits after period in many cases). The errors go as follows:
```
(cqgui) jalovisko@home ~/dev/cqMore/tests $ python test_matrix.py 
...F...F..F
======================================================================
FAIL: test_rotation (__main__.TestMatrix)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test_matrix.py", line 110, in test_rotation
    self.assertTupleEqual(expected, rotated)
AssertionError: Tuples differ: ((0.5773502691896258, 0.5773502691896258, 0.5773502691896258[193 chars]422)) != ((0.5773502691896257, 0.5773502691896258, 0.5773502691896258[190 chars]421))

First differing element 0:
(0.5773502691896258, 0.5773502691896258, 0.5773502691896258)
(0.5773502691896257, 0.5773502691896258, 0.5773502691896258)

Diff is 944 characters long. Set self.maxDiff to None to see it.

======================================================================
FAIL: test_scaling (__main__.TestMatrix)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test_matrix.py", line 59, in test_scaling
    self.assertTupleEqual(expected, scaled_points)
AssertionError: Tuples differ: ((2.0[123 chars]660254037844385, 6.123233995736766e-17), (0, 0, -1), (0, 0, 1)) != ((2.0[123 chars]660254037844384, 6.123233995736766e-17), (0, 0, -1), (0, 0, 1))

First differing element 2:
(-1.0000000000000009, -0.8660254037844385, 6.123233995736766e-17)
(-1.0000000000000009, -0.8660254037844384, 6.123233995736766e-17)

  ((2.0, 0.0, 6.123233995736766e-17),
   (-0.9999999999999996, 0.8660254037844387, 6.123233995736766e-17),
-  (-1.0000000000000009, -0.8660254037844385, 6.123233995736766e-17),
?                                          ^

+  (-1.0000000000000009, -0.8660254037844384, 6.123233995736766e-17),
?                                          ^

   (0, 0, -1),
   (0, 0, 1))

======================================================================
FAIL: test_translation (__main__.TestMatrix)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test_matrix.py", line 69, in test_translation
    self.assertTupleEqual(expected, translated)
AssertionError: Tuples differ: ((3.5[467 chars]922195, -0.8660254037844385), (3.0, -0.5000000[2755 chars], 1)) != ((3.5[467 chars]9221946, -0.8660254037844385), (3.0, -0.500000[2757 chars], 1))

First differing element 8:
(2.7499999999999996, -0.4330127018922195, -0.8660254037844385)
(2.7499999999999996, -0.43301270189221946, -0.8660254037844385)

Diff is 4211 characters long. Set self.maxDiff to None to see it.

----------------------------------------------------------------------
Ran 11 tests in 0.006s

FAILED (failures=3)
```